### PR TITLE
Do not keep deploy history of gh-pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,3 +32,4 @@ jobs:
           publish_dir: ./build
           user_name: 'Arnaud Bailly'
           user_email: arnaud.bailly@iohk.io
+          force_orphan: true


### PR DESCRIPTION
The git history of deployed builds is not really helpful and leads to a long wielded git history. Using force_orphan does only push a single commit on the 'gh-pages' branch based directly on top of the last published source commit.