### PR TITLE
Add `Mithril` entry to drop-down `Topics` menu

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -98,6 +98,7 @@ const config = {
               { to: 'quarterly/tags/cli-api-quarterly', label: 'Node CLI & API Quarterly' },
               { to: 'tags/crypto', label: 'Crypto' },
               { to: 'tags/goedel', label: 'Goedel' },
+              { to: 'tags/mithril', label: 'Mithril' },
             ],
           },
           { to: 'archive', label: 'Archive', position: 'right' },


### PR DESCRIPTION
This PR adds a `Mithril` entry in the `Topics` drop-down menu of the website