### PR TITLE
Add a 'Reports' category

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -31,6 +31,17 @@ const config = {
         editUrl
       },
     ],
+    [
+      'content-blog',
+      /** @type {import('@docusaurus/plugin-content-blog').Options} */
+      {
+        id: 'reports',
+        routeBasePath: 'reports',
+        path: 'reports',
+        authorsMapPath: 'authors.yml',
+        editUrl
+      },
+    ],
   ],
 
   scripts: [
@@ -82,6 +93,7 @@ const config = {
         items: [
           { to: '/', label: 'Home', position: 'right' },
           { to: '/quarterly', label: 'Quarterly', position: 'right' },
+          { to: '/reports', label: 'Reports', position: 'right' },
           {
             type: 'dropdown',
             to: 'tags',
@@ -99,6 +111,9 @@ const config = {
               { to: 'tags/crypto', label: 'Crypto' },
               { to: 'tags/goedel', label: 'Goedel' },
               { to: 'tags/mithril', label: 'Mithril' },
+              { to: 'tags/performance-tracing', label: 'Performance & Tracing' },
+              { to: 'reports/tags/benchmarking-reports', label: 'Benchmarking Reports' },          
+              
             ],
           },
           { to: 'archive', label: 'Archive', position: 'right' },

--- a/reports/2023-12-performance-8.7.1.md
+++ b/reports/2023-12-performance-8.7.1.md
@@ -1,0 +1,15 @@
+---
+title: Benchmarking -- Node 8.7.1
+slug: 2023-12-performance-8.7.1
+authors: mgmeier
+tags: [benchmarking-reports]
+hide_table_of_contents: false
+---
+
+## `cardano-node 8.7.1-pre`
+
+
+### Foobar
+
+TBD.  
+

--- a/reports/authors.yml
+++ b/reports/authors.yml
@@ -1,0 +1,5 @@
+mgmeier:
+  image_url: https://github.com/mgmeier.png
+  name: Michael Karg
+  title: Performance and Tracing Team Lead
+  url: https://github.com/mgmeier


### PR DESCRIPTION
A new category for publication of reports.
One of its goals is to host selected benchmarking reports accompanying node releases on mainnet.
It is not meant to be a benchmark-only category, however.